### PR TITLE
Change dev-master requirement to compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "fromholdio/silverstripe-superlinker": "dev-master",
         "symbiote/silverstripe-gridfieldextensions": "^4.0.0",
         "unclecheese/display-logic": "^3.0.0",
-        "fromholdio/silverstripe-gridfield-limiter": "dev-master"
+        "fromholdio/silverstripe-gridfield-limiter": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
fromholdio/silverstripe-gridfield-limiter dev-master requires SS6. Setting required version explicitly to the SS5 version, for this module's SS5 version, is required to fix.